### PR TITLE
Add git-trav-priv to access to private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ ZSH plugin to open Travis CI page for the current repo (if it exists).
 
 ```sh
 $ git-trav
+$ git-trav-priv
 ```
 
 ### As a git alias

--- a/travis.plugin.zsh
+++ b/travis.plugin.zsh
@@ -28,10 +28,29 @@ __trav_get_url() {
   url="${url%/*}"
   url="https://travis-ci.org/$url"
 }
-
+__trav_get_priv_url() {
+  repo_url=$(git config --get remote.origin.url)
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  url="${repo_url/git/https}"
+  url="${url/httpshub/github}"
+  url="${url/.git//}"
+  url="${url/https@/https://}"
+  url="${url/com:/com/}"
+  url="${url/https:\/\/github.com\//}"
+  url="${url%/*}"
+  url="https://travis-ci.com/$url"
+}
 git-trav() {
   if __trav_check_yml; then
     __trav_get_url
+    __trav_open $url
+  else
+    echo "No .travis.yml file found."
+  fi
+}
+git-trav-priv() {
+  if __trav_check_yml; then
+    __trav_get_priv_url
     __trav_open $url
   else
     echo "No .travis.yml file found."


### PR DESCRIPTION
Using git-trav-priv you can access private repos that have the travis-ci.org url
